### PR TITLE
fix(stdin): read full subject from stdin, till EOF

### DIFF
--- a/src/msc2.c
+++ b/src/msc2.c
@@ -283,7 +283,7 @@ int main(int argc, char **argv) {
     //   or read from stdin
     else {
         i = 0;
-        while ((ci = getchar()) != '\n' && ci != EOF && i < FILESIZEMAX) {
+        while ((ci = getchar()) && ci != EOF && i < FILESIZEMAX) {
             subject[i++] = ci;
         }
         subject_length = (int)strlen(subject);

--- a/src/msc3.cc
+++ b/src/msc3.cc
@@ -128,7 +128,12 @@ int main(int argc, char ** argv) {
     }
     //   or read from stdin
     else {
-        std::getline(std::cin, subject);
+      // don't skip the whitespace while reading
+      std::cin >> std::noskipws;
+      // use stream iterators to copy the stream to a string
+      std::istream_iterator<char> it(std::cin);
+      std::istream_iterator<char> end;
+      subject.assign(it, end);
     }
 
     debugvalue(debuglevel, std::string("SUBJECT"), subject);


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Read from stdin until EOF. This way the subject can have `\n` or `\r`, like in a regular file.