### PR TITLE
fix(build): clang does not have this header

### DIFF
--- a/src/msc3.cc
+++ b/src/msc3.cc
@@ -4,7 +4,6 @@
 #include <fstream>
 #include <unistd.h>
 #include <ctype.h>
-#include <bits/stdc++.h>
 #include "regex.h"
 #include "regexutils.h"
 


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Fixes build in macos/clang compiler.