### PR TITLE
fix(build): move linker flag to LDFLAGS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,6 @@
-AM_CXXFLAGS = -Wall -g -O0 -lpcre -std=c++11 -fPIC
-AM_CFLAGS = -Wall -g -O0 -lpcre
+AM_CXXFLAGS = -Wall -g -O0 -std=c++11 -fPIC
+AM_CFLAGS = -Wall -g -O0
+AM_LDFLAGS=-lpcre
 
 bin_PROGRAMS = pcre4msc2 pcre4msc3
 


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

Fixes `warning: -lpcre: 'linker' input unused [-Wunused-command-line-argument]`